### PR TITLE
FIX: 修复无法正常运行的问题外加更新使用文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,42 @@ A flake wrapper of the unofficial version of WeChat Web DevTools from [msojocs](
 
 # Usage
 
-- Add GitHub URL into `inputs` section in your `flake.nix`
+## Temporary use: 
+  Do not add packages to configuration files
 
-```nix
-{
-  # ...
-  inputs.wechat-devtools.url = "github:MaikoTan/wechat-devtools";
-}
+  `nix run github:MaikoTan/wechat-devtools`
 
-- Add `wechat-devtools` into your installed package list, for example
+## Permanently use:
+  Add packages to your configuration flake
 
-```nix
-{ pkgs, wechat-devtools }:
-{
-  environment.systemPackages = [
+  ### Add `wechat-devtools` into <flake>.inputs
+
+  ```nix
+  {
     # ...
-    wechat-devtools
-  ]
-}
-```
+    inputs.wechat-devtools.url = "github:MaikoTan/wechat-devtools";
+  }
+  ```
+  ### Add `wechat-devtools` by pass nix expression
+
+  ```nix
+  { # flake.nix
+    inputs.nixpkgs.url = ...;
+    inputs.wechat-devtools.url = "github:MaikoTan/wechat-devtools";
+    
+    outputs = { nixpkgs, wechat-devtools }: {
+      nixosConfigurations.<machine_name> = nixpkgs.lib.nixosSystem {
+        specialArgs = { inherit inputs; }
+        # ...
+      };
+    };
+  }
+
+  # configuration.nix or something
+  { inputs, ... }: {
+    environment.systemPackages = with pkgs; [ 
+      vim wget curl ... 
+      inputs.wechat-devtools
+    ];
+  }
+  ```

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,6 @@
             inherit pname version src;
           };
           in ''
-            install -m 755 -D ${appimageContents}/AppRun $out/bin/${pname}
-            patchShebangs $out/bin/${pname}
             install -m 444 -D ${appimageContents}/io.github.msojocs.wechat_devtools.desktop \
               $out/share/applications/wechat-devtools.desktop
             install -m 444 -D ${appimageContents}/wechat-devtools.png \

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
           in ''
             install -m 444 -D ${appimageContents}/io.github.msojocs.wechat_devtools.desktop \
               $out/share/applications/wechat-devtools.desktop
+            substituteInPlace $out/share/applications/wechat-devtools.desktop \
+              --replace "Exec=bin/wechat-devtools" "Exec=$out/bin/${pname}"
             install -m 444 -D ${appimageContents}/wechat-devtools.png \
               $out/share/icons/hicolor/512x512/apps/wechat-devtools.png
           '';


### PR DESCRIPTION
修复说明：@MaikoTan 
考虑到当前使用的 appimagetools.wrapType2 底层实际上调用了 buildFHSEnv。没有必要额外的覆盖 AppRun，就算仍然想保存 AppRun 作为 wechat-devtools and wechat-devtools-cli 的区分脚本也应该采用其他方法。

1. appimageTools.wrapType2 >> wrapAppImage >> buildFHSEnv [appimageTools](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/appimage/default.nix)
2. `${appimageContents}/bin/${pname}` 会自动软连接到 `$out/bin/${pname}` [build-fhsenv-bubblewrap](https://github.com/NixOS/nixpkgs/blob/858fc0ec230e6d9d76fa95bd77d46f3ea5e64629/pkgs/build-support/build-fhsenv-bubblewrap/default.nix#L358) L358, L21
